### PR TITLE
Final tweaks for Strimzi TLS trust auto-discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#2820](https://github.com/kroxylicious/kroxylicious/issues/2820): feat(operator): add automatic TLS trust discovery for Strimzi-managed Kafka clusters via `trustStrimziCaCertificate` field in KafkaService
 * [#3769](https://github.com/kroxylicious/kroxylicious/pull/3769): fix(runtime): messages enter Filter chain before Transport Subject built
 * [#3757](https://github.com/kroxylicious/kroxylicious/issues/3757): fix(runtime): trigger read after HAProxy message to prevent deadlock when autoread disabled
 * [#1295](https://github.com/kroxylicious/kroxylicious/issues/1295): feat(aws-kms): add IRSA and EKS Pod Identity credential providers, and restructure AWS KMS credential configuration under a new `credentials` node (see [note](#note-021-aws-kms-credentials-restructure))

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
@@ -72,8 +72,11 @@ spec:
                       type: string
                     trustStrimziCaCertificate:
                       description: |
-                        if true, the proxy will automatically trust the certificate published by Strimzi
-                        when connecting to a TLS protected upstream. Not recommended for production use.
+                        If true, automatically trust the Strimzi cluster CA certificate for TLS connections
+                        to the upstream Kafka cluster. The proxy will discover the CA certificate from the
+                        Secret created by Strimzi (<kafka-name>-cluster-ca-cert in the same namespace).
+
+                        Security note: This delegates certificate trust to the Strimzi operator.
                       type: boolean
                   required:
                     - name

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -728,6 +728,7 @@ public class ResourcesUtil {
                                                                             StrimziKafkaRef strimziKafkaRef, KafkaServiceStatusFactory statusFactory) {
 
         String strimziCaCertSecretName = strimziKafkaRef.getRef().getName() + STRIMZI_CLUSTER_CA_CERT_SECRET_SUFFIX;
+        // Strimzi creates CA certificate secrets in the same namespace as the Kafka CR.
         var clusterCaSecret = context.getClient().secrets().inNamespace(resource.getMetadata().getNamespace())
                 .withName(strimziCaCertSecretName).get();
         if (clusterCaSecret == null) {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceReconciler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceReconciler.java
@@ -29,7 +29,10 @@ import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEven
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.listener.ListenerStatus;
 
+import io.kroxylicious.kubernetes.api.common.CertificateRef;
+import io.kroxylicious.kubernetes.api.common.CipherSuites;
 import io.kroxylicious.kubernetes.api.common.Condition;
+import io.kroxylicious.kubernetes.api.common.Protocols;
 import io.kroxylicious.kubernetes.api.common.TrustAnchorRef;
 import io.kroxylicious.kubernetes.api.common.TrustAnchorRefBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
@@ -303,7 +306,16 @@ public final class KafkaServiceReconciler implements
                                             @Nullable TrustAnchorRef trustAnchorRef) {
 
         String checksum = computeChecksum(allReferents);
-        var statusTls = buildStatusTls(service, trustAnchorRef);
+
+        var specTls = Optional.ofNullable(service.getSpec())
+                .map(KafkaServiceSpec::getTls)
+                .orElse(null);
+
+        var statusTls = buildStatusTls(
+                trustAnchorRef,
+                specTls != null ? specTls.getCertificateRef() : null,
+                specTls != null ? specTls.getProtocols() : null,
+                specTls != null ? specTls.getCipherSuites() : null);
 
         if (service.getSpec().getStrimziKafkaRef() != null) {
             return buildStrimziBasedStatus(service, context, checksum, statusTls);
@@ -323,27 +335,21 @@ public final class KafkaServiceReconciler implements
 
     @Nullable
     private io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicestatus.Tls buildStatusTls(
-                                                                                          KafkaService service,
-                                                                                          @Nullable TrustAnchorRef trustAnchorRef) {
+                                                                                          @Nullable TrustAnchorRef trustAnchorRef,
+                                                                                          @Nullable CertificateRef certificateRef,
+                                                                                          @Nullable Protocols protocols,
+                                                                                          @Nullable CipherSuites cipherSuites) {
 
-        var tls = Optional.ofNullable(service.getSpec())
-                .map(KafkaServiceSpec::getTls)
-                .orElse(null);
-
-        if (tls == null && trustAnchorRef == null) {
+        if (trustAnchorRef == null && certificateRef == null && protocols == null && cipherSuites == null) {
             return null;
         }
 
-        var builder = new io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicestatus.TlsBuilder()
-                .withTrustAnchorRef(trustAnchorRef);
-
-        if (tls != null) {
-            builder.withCertificateRef(tls.getCertificateRef())
-                    .withProtocols(tls.getProtocols())
-                    .withCipherSuites(tls.getCipherSuites());
-        }
-
-        return builder.build();
+        return new io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicestatus.TlsBuilder()
+                .withTrustAnchorRef(trustAnchorRef)
+                .withCertificateRef(certificateRef)
+                .withProtocols(protocols)
+                .withCipherSuites(cipherSuites)
+                .build();
     }
 
     private KafkaService buildStrimziBasedStatus(

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStatusFactory.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStatusFactory.java
@@ -93,7 +93,7 @@ public class KafkaServiceStatusFactory extends StatusFactory<KafkaService> {
                                              Condition.Type type,
                                              String checksum,
                                              String bootstrapServers,
-                                             Tls tls) {
+                                             @Nullable Tls tls) {
         Condition trueCondition = newTrueCondition(observedProxy, type);
         return serviceStatusPatch(observedProxy, trueCondition, checksum, bootstrapServers, tls);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStatusFactory.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStatusFactory.java
@@ -49,11 +49,8 @@ public class KafkaServiceStatusFactory extends StatusFactory<KafkaService> {
                 .withNewStatus()
                     .withObservedGeneration(ResourcesUtil.generation(observedIngress))
                     .withConditions(ResourceState.newConditions(Optional.ofNullable(observedIngress.getStatus()).map(KafkaServiceStatus::getConditions).orElse(List.of()), ResourceState.of(condition)))
-                    .withBootstrapServers(bootstrapServers);
-
-        if (tls != null) {
-            statusBuilder.withTls(tls);
-        }
+                    .withBootstrapServers(bootstrapServers)
+                    .withTls(tls);
 
         return statusBuilder.endStatus().build();
         // @formatter:on

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
@@ -93,9 +93,6 @@ class AllReconcilersIT {
     private static final String CLUSTER_FOO_CLUSTER_IP_INGRESS = "foo-cluster-ip";
     private static final String CLUSTER_FOO_SERVICE = "foo-service";
     private static final String CLUSTER_FOO_FILTER = "foo-filter";
-    private static final String STRIMZI_CLUSTER_CA_CERT_SUFFIX = "-cluster-ca-cert";
-    private static final String STRIMZI_CA_CERT_KEY = "ca.crt";
-    private static final String STRIMZI_TLS_LISTENER = "tls";
     private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
 
     // the initial operator image pull can take a long time and interfere with the tests
@@ -428,7 +425,9 @@ class AllReconcilersIT {
      * Nested class for tests that require Strimzi CRD
      */
     @Nested
-    class StrimziKafkaRefTests {
+    class StrimziKafkaIntegrationTests {
+
+        private static final String STRIMZI_TLS_LISTENER = "tls";
 
         @BeforeAll
         static void setUpStrimziCrd() {
@@ -475,21 +474,21 @@ class AllReconcilersIT {
             // this status since the Strimzi operator is not running.
             testActor.patchStatus(new KafkaBuilder(kafka)
                     .withNewStatus()
-                        .withListeners(new ListenerStatusBuilder()
-                                .withName(STRIMZI_TLS_LISTENER)
-                                .withAddresses(new ListenerAddressBuilder()
-                                        .withHost("kafka.example.com")
-                                        .withPort(9093)
-                                        .build())
-                                .build())
+                        .addNewListener()
+                            .withName(STRIMZI_TLS_LISTENER)
+                            .addNewAddress()
+                                    .withHost("kafka.example.com")
+                                    .withPort(9093)
+                            .endAddress()
+                        .endListener()
                     .endStatus()
                     .build());
 
             testActor.create(new SecretBuilder()
                     .withNewMetadata()
-                        .withName(kafkaName + STRIMZI_CLUSTER_CA_CERT_SUFFIX)
+                        .withName(kafkaName + ResourcesUtil.STRIMZI_CLUSTER_CA_CERT_SECRET_SUFFIX)
                     .endMetadata()
-                    .addToData(STRIMZI_CA_CERT_KEY, "dGVzdC1jYQ==")
+                    .addToData(ResourcesUtil.STRIMZI_CLUSTER_CA_BUNDLE, "dGVzdC1jYQ==")
                     .build());
 
             var myService = editableStrimziService(CLUSTER_FOO_SERVICE, kafkaName, STRIMZI_TLS_LISTENER).build();
@@ -511,6 +510,24 @@ class AllReconcilersIT {
             // Then
             assertResourcesAttainCondition(AllReconcilersIT::resourceReady, myProxy);
             assertResourcesAttainCondition(AllReconcilersIT::refsResolved, myCluster, myIngress, myService);
+        }
+
+        private static KafkaServiceBuilder editableStrimziService(String name, String kafkaName, String listenerName) {
+            // @formatter:off
+            return new KafkaServiceBuilder()
+                    .withNewMetadata()
+                    .withName(name)
+                    .endMetadata()
+                    .withNewSpec()
+                    .withNewStrimziKafkaRef()
+                    .withListenerName(listenerName)
+                    .withTrustStrimziCaCertificate(true)
+                    .withNewRef()
+                    .withName(kafkaName)
+                    .endRef()
+                    .endStrimziKafkaRef()
+                    .endSpec();
+            // @formatter:on
         }
     }
 
@@ -599,24 +616,6 @@ class AllReconcilersIT {
                 .withNewSpec()
                     .withBootstrapServers("example.com:5555")
                     .withNodeIdRanges(new NodeIdRangesBuilder().withStart(0L).withEnd(0L).build())
-                .endSpec();
-        // @formatter:on
-    }
-
-    private static KafkaServiceBuilder editableStrimziService(String name, String kafkaName, String listenerName) {
-        // @formatter:off
-        return new KafkaServiceBuilder()
-                .withNewMetadata()
-                    .withName(name)
-                .endMetadata()
-                .withNewSpec()
-                    .withNewStrimziKafkaRef()
-                        .withListenerName(listenerName)
-                        .withTrustStrimziCaCertificate(true)
-                        .withNewRef()
-                            .withName(kafkaName)
-                        .endRef()
-                    .endStrimziKafkaRef()
                 .endSpec();
         // @formatter:on
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
@@ -41,8 +41,6 @@ import io.fabric8.kubernetes.client.dsl.Updatable;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
-import io.strimzi.api.kafka.model.kafka.listener.ListenerAddressBuilder;
-import io.strimzi.api.kafka.model.kafka.listener.ListenerStatusBuilder;
 
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.common.FilterRefBuilder;

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
@@ -315,21 +315,26 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
                                                                                boolean trustStrimziCa,
                                                                                @Nullable TrustAnchorRef explictTrust) {
         // @formatter:off
-        return new KafkaServiceBuilder()
+        var builder = new KafkaServiceBuilder()
                 .withNewMetadata()
                     .withName(serviceName)
                 .endMetadata()
                 .editOrNewSpec()
                     .withNewStrimziKafkaRef()
                         .withListenerName(listenerName)
-                         .withTrustStrimziCaCertificate(trustStrimziCa)
-                     .withNewRef()
-                         .withName(KAFKA_RESOURCE_NAME)
-                    .endRef()
-                .endStrimziKafkaRef()
-                .withNewTls()
+                        .withTrustStrimziCaCertificate(trustStrimziCa)
+                        .withNewRef()
+                            .withName(KAFKA_RESOURCE_NAME)
+                        .endRef()
+                    .endStrimziKafkaRef();
+
+        if (explictTrust != null) {
+            builder.withNewTls()
                     .withTrustAnchorRef(explictTrust)
-                .endTls().endSpec().build();
+                .endTls();
+        }
+
+        return builder.endSpec().build();
         // @formatter:on
     }
 


### PR DESCRIPTION
This PR addresses code review feedback from the main PR (#3437):

## Changes

- **Use constants instead of magic values**: Tests now reference `ResourcesUtil.STRIMZI_CLUSTER_CA_CERT_SECRET_SUFFIX` and `ResourcesUtil.STRIMZI_CLUSTER_CA_BUNDLE` instead of duplicating the strings
- **Add namespace assumption comment**: Clarified that Strimzi CA secrets are expected in the same namespace
- **Improve CRD description**: Softened the security warning for `trustStrimziCaCertificate` field with clearer, more accurate description
- **Fix status cleanup**: Ensure `status.tls` is properly cleared when TLS config is removed from spec
- **Add CHANGELOG entry**: Document this user-facing feature

## Review

These are minor improvements that don't change functionality, just improve code quality and documentation.